### PR TITLE
Fixes the changed "scope" method, modified in active_record 5.0.3

### DIFF
--- a/lib/light/decorator/concerns/associations/collection_proxy.rb
+++ b/lib/light/decorator/concerns/associations/collection_proxy.rb
@@ -28,8 +28,8 @@ module Light
           private
 
           def override_scope(options)
-            @association.define_singleton_method :scope do |opts = {}|
-              super(opts).decorate(options)
+            @association.define_singleton_method :scope do
+              super().decorate(options)
             end
           end
 


### PR DESCRIPTION
Makes light-decorator compatible with active_record >= 5.0.3